### PR TITLE
Detects user's region

### DIFF
--- a/11-monitoring/application-monitoring-with-cloudwatch-logs/user_data.sh
+++ b/11-monitoring/application-monitoring-with-cloudwatch-logs/user_data.sh
@@ -10,7 +10,7 @@ sudo cat <<EOF >>/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.js
     "agent": {
         "metrics_collection_interval": 60,
         "run_as_user": "root",
-        "region": "us-east-1",
+        "region": "{item("meta-data/placement/availability-zone")}",
         "debug": true
     },
     "logs": {


### PR DESCRIPTION
Welcome to take or reject this if you want, but I got confused during the lab cause I as on `us-east-2` and could not figure out why it seemed like my log group was not getting created.

This would just detect the user's region for them.
